### PR TITLE
Fixed Prototype Pollution Bug by ignoring dangerous keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ function assign(target, source) {
 	for (let i in source) {
 		if (Array.isArray(target[i])) {
 			concat(target[i], source[i]);
-		} else if (typeof(target[i]) == "object") {
+		} else if (typeof(target[i]) == "object" && !/^__proto__|constructor|prototype$/.test(i)) {
 			assign(target[i], source[i]);
 		} else {
 			target[i] = source[i];


### PR DESCRIPTION
### :bar_chart: Metadata *

`join-assign` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-join-assign

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const { assign } = require('./src')

console.log('Before: ' + {}.polluted)
assign({}, JSON.parse('{"__proto__": {"polluted": true}}'))
console.log('After: ' + {}.polluted)
```
2. Execute the following commands in terminal:
```bash
npm i join-assign # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : true
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/107614350-27838600-6c70-11eb-9e8c-9946fa4b74d8.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
